### PR TITLE
SWITCHYARD-297

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,18 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <configLocation>checkstyle/checkstyle.xml</configLocation>
+          <consoleOutput>false</consoleOutput>
+          <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
+          <failsOnError>false</failsOnError>
+          <useFile/>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>2.3.2-SNAPSHOT</version>
@@ -430,6 +442,35 @@
           </plugin>
         </plugins>
       </reporting>
+    </profile>
+    <profile>
+      <!-- https://cwiki.apache.org/confluence/display/MAVEN/Maven+3.x+and+site+plugin -->
+      <id>maven-3</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <file>
+          <exists>${basedir}</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>3.0-beta-3</version>
+            <configuration>
+              <siteDirectory>build/src/site</siteDirectory>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-descriptor</id>
+                <goals>
+                  <goal>attach-descriptor</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
   <reporting>


### PR DESCRIPTION
compatibility issues: affects checkstyle configuration location (added to plugins) and site plugin version (3.0-beta-3 when using maven 3).
