### PR TITLE
SWITCHYARD-515: Upgrade Drools from 5.2.1 to 5.3.1 and jBPM from 5.1.1 to 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <version.commons.httpclient>3.1</version.commons.httpclient>
     <version.commonman>1.0</version.commonman>
     <version.dom4j>1.6.1</version.dom4j>
-    <version.drools>5.2.1.Final</version.drools>
+    <version.drools>5.3.1.Final</version.drools>
     <version.ecj>3.5.1</version.ecj>
     <version.forge>1.0.0.Beta3</version.forge>
     <version.freemarker>2.3.15</version.freemarker>
@@ -102,7 +102,7 @@
     <version.jaxen>1.1.1</version.jaxen>
     <version.javassist>3.12.0.GA</version.javassist>
     <version.javax.jms>1.1</version.javax.jms>
-    <version.jbpm>5.1.1.Final</version.jbpm>
+    <version.jbpm>5.2.0.Final</version.jbpm>
     <!-- Used with core/test for testing -->
     <version.jboss.interceptor>2.0.0.Alpha3</version.jboss.interceptor>
     <version.jboss.deployers>2.2.0.GA</version.jboss.deployers>
@@ -130,7 +130,7 @@
     <version.mina>2.0.1</version.mina>
     <version.milyn>1.5</version.milyn>
     <version.mockito>1.8.5</version.mockito>
-    <version.mvel>2.1.Beta6</version.mvel>
+    <version.mvel>2.1.0.drools4</version.mvel>
     <version.naming>5.0.5.Final</version.naming>
     <version.netty>3.2.1.Final</version.netty>
     <version.protostuff>1.0.4</version.protostuff>
@@ -939,6 +939,7 @@
          <groupId>javax.jms</groupId>
          <artifactId>jms</artifactId>
          <version>${version.javax.jms}</version>
+         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>javax.persistence</groupId>


### PR DESCRIPTION
SWITCHYARD-515: Upgrade Drools from 5.2.1 to 5.3.1 and jBPM from 5.1.1 to 5.2.0
https://issues.jboss.org/browse/SWITCHYARD-515
