### PR TITLE
SWITCHYARD-710: Allow direct storage of XML Nodes as Context properties from ContextMappers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -780,6 +780,11 @@
       </dependency>
       <dependency>
          <groupId>org.switchyard.components</groupId>
+         <artifactId>switchyard-component-common-composer</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.switchyard.components</groupId>
          <artifactId>switchyard-component-common-rules</artifactId>
          <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
SWITCHYARD-710: Allow direct storage of XML Nodes as Context properties from ContextMappers
https://issues.jboss.org/browse/SWITCHYARD-710
