### PR TITLE
[SWITCHYARD-958] - Added RESTEasy quickstart dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -902,6 +902,11 @@
       </dependency>
       <dependency>
          <groupId>org.switchyard.quickstarts</groupId>
+         <artifactId>switchyard-quickstart-rest-binding</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.switchyard.quickstarts</groupId>
          <artifactId>switchyard-quickstart-rules-camel-cbr</artifactId>
          <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-958
