### PR TITLE
SWITCHYARD-1069: Separate picketlink from core security classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -782,6 +782,11 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard</groupId>
+                <artifactId>switchyard-security-jboss</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.switchyard</groupId>
                 <artifactId>switchyard-serial</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
SWITCHYARD-1069: Separate picketlink from core security classes
https://issues.jboss.org/browse/SWITCHYARD-1069
