### PR TITLE
SWITCHYARD-1140 operationSelector & contextMapper can not be specified t...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,6 +816,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.switchyard</groupId>
+                <artifactId>switchyard-selector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+             <dependency>
                 <groupId>org.switchyard.components</groupId>
                 <artifactId>switchyard-component-bean</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
...ogether

Move OperationSelector from component-common to core
