### PR TITLE
SWITCHYARD-1289 Change riftsaw version to 3.0.0-SNAPSHOT to pick up head...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
         <version.protostuff>1.0.7</version.protostuff>
         <!-- Needed until AS7 is upgraded with this version -->
         <version.resteasy>2.3.4.Final</version.resteasy>
-        <version.riftsaw.ode>3.0.0.20130307-M5</version.riftsaw.ode>
-        <version.riftsaw.engine>3.0.0.20130307-M5</version.riftsaw.engine>
+        <version.riftsaw.ode>3.0.0-SNAPSHOT</version.riftsaw.ode>
+        <version.riftsaw.engine>3.0.0-SNAPSHOT</version.riftsaw.engine>
         <version.riftsaw.console>2.4.3.Final</version.riftsaw.console>
         <version.rhino>1.7R2</version.rhino>
         <version.saxon>9.2.1.5</version.saxon>


### PR DESCRIPTION
...er passing fix

Riftsaw snapshot has been pushed to nexus.
