### PR TITLE
SWITCHYARD-1365 beanshell bsh version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.antlr>3.3</version.antlr>
         <version.axiom>1.2.8</version.axiom>
         <version.batik>1.7</version.batik>
-        <version.beanshell>2.0b5</version.beanshell>
+        <version.beanshell>2.0b4</version.beanshell>
         <version.camel>2.10.0</version.camel>
         <version.cxf>2.6.1</version.cxf>
         <version.clojure>1.3.0-alpha5</version.clojure>
@@ -1637,6 +1637,10 @@
                     <exclusion>
                         <groupId>com.sun.xml.bind</groupId>
                         <artifactId>jaxb-impl</artifactId>
+                    </exclusion>
+		    <exclusion>
+			<groupId>org.beanshell</groupId>
+			<artifactId>bsh</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
Downgrade bsh to 2.0b4 to align with EAP.
