### PR TITLE
SWITCHYARD-1623: Upgrade KIE/Drools/jBPM from 6.0.0.Beta4 to 6.0.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.commons.net>2.2</version.commons.net>
         <version.commons.ssl>0.3.9</version.commons.ssl>
         <version.deltaspike>${version.org.apache.deltaspike}</version.deltaspike>
-        <version.drools>6.0.0.Beta4</version.drools>
+        <version.drools>6.0.0.CR1</version.drools>
         <version.ecj>3.7.2</version.ecj>
         <version.forge>1.2.2.Final</version.forge>
         <version.forge.arquillian>1.0.0.CR7</version.forge.arquillian>
@@ -95,14 +95,14 @@
         <version.jbosseap>6.1</version.jbosseap>
         <version.jbossws.spi>2.1.2.Final</version.jbossws.spi>
         <version.jbossws.jboss720.server.integration>4.2.0-SNAPSHOT</version.jbossws.jboss720.server.integration>
-        <version.jbpm>6.0.0.Beta4</version.jbpm>
+        <version.jbpm>6.0.0.CR1</version.jbpm>
         <version.jettison>1.2</version.jettison>
         <version.jsch>0.1.48</version.jsch>
         <version.jta>1.1</version.jta>
         <version.junit>4.10</version.junit>
         <version.jruby>1.7.2</version.jruby>
         <version.jython>2.5.3</version.jython>
-        <version.kie>6.0.0.Beta4</version.kie>
+        <version.kie>6.0.0.CR1</version.kie>
         <version.littleproxy>0.5.3</version.littleproxy>
         <version.maven.plugin.plugin>3.1</version.maven.plugin.plugin>
         <version.milyn>1.5.1</version.milyn>


### PR DESCRIPTION
SWITCHYARD-1623: Upgrade KIE/Drools/jBPM from 6.0.0.Beta4 to 6.0.0.CR1
https://issues.jboss.org/browse/SWITCHYARD-1623
