### PR TITLE
[SWITCHYARD-1744] - Removed SNAPSHOT dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <version.jbossas.openshift>7.1.0.Final</version.jbossas.openshift>
         <version.jbosseap>6.1</version.jbosseap>
         <version.jbossws.spi>2.1.2.Final</version.jbossws.spi>
-        <version.jbossws.jboss720.server.integration>4.2.0-SNAPSHOT</version.jbossws.jboss720.server.integration>
+        <version.jbossws.jboss720.server.integration>4.2.0.Final</version.jbossws.jboss720.server.integration>
         <version.jboss.logging>3.1.2.GA</version.jboss.logging>
         <version.jboss.logging.processor>1.1.0.Final</version.jboss.logging.processor>
         <version.jbpm>6.0.0.CR3</version.jbpm>


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-1744
