### PR TITLE
SWITCHYARD-1729: Security context is not propagated between service calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1286,6 +1286,11 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard.quickstarts.demos</groupId>
+                <artifactId>switchyard-quickstart-demo-policy-security-basic-propagate</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.switchyard.quickstarts.demos</groupId>
                 <artifactId>switchyard-quickstart-demo-policy-security-cert</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
SWITCHYARD-1729: Security context is not propagated between service calls
https://issues.jboss.org/browse/SWITCHYARD-1729
