### PR TITLE
SWITCHYARD-1764 Add opencsv dependency for Smooks CSV Parsing Exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <version.mock.javamail>1.9</version.mock.javamail>
         <version.mvel>2.1.6.Final</version.mvel>
         <version.netty>3.2.6.Final</version.netty>
+        <version.opencsv>2.3</version.opencsv>
         <!--<version.org.jboss.spec.javax.resource16>1.0.0.Final</version.org.jboss.spec.javax.resource16>-->
         <version.quartz>1.8.5</version.quartz>
         <version.qpid>0.18</version.qpid>
@@ -2373,6 +2374,11 @@
                 <groupId>org.mvel</groupId>
                 <artifactId>mvel2</artifactId>
                 <version>${version.mvel}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sf.opencsv</groupId>
+                <artifactId>opencsv</artifactId>
+                <version>2.1</version>
             </dependency>
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
Adding opencsv dependency to fix a Smooks CSV Parsing ClassNotFoundException.      Checked to see what version of opencsv is being used elsewhere, the community BOM specifies opencsv 2.3, so we'll use that version here to prevent mismatches.

https://github.com/jboss-integration/jboss-integration-platform-bom/blob/master/pom.xml#L136
