### PR TITLE
SWITCHYARD-1825: Upgrade KIE/Drools/jBPM from 6.0.0.CR5 to 6.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <version.commons.net>2.2</version.commons.net>
         <version.commons.ssl>0.3.9</version.commons.ssl>
         <version.deltaspike>${version.org.apache.deltaspike}</version.deltaspike>
-        <version.drools>6.0.0.CR5</version.drools>
+        <version.drools>6.0.0.Final</version.drools>
         <version.ecj>3.7.2</version.ecj>
         <version.ems>1.3</version.ems>
         <version.forge>1.2.2.Final</version.forge>
@@ -100,14 +100,14 @@
         <version.jbossws.jboss720.server.integration>4.2.0.Final</version.jbossws.jboss720.server.integration>
         <version.jboss.logging>3.1.2.GA</version.jboss.logging>
         <version.jboss.logging.processor>1.1.0.Final</version.jboss.logging.processor>
-        <version.jbpm>6.0.0.CR5</version.jbpm>
+        <version.jbpm>6.0.0.Final</version.jbpm>
         <version.jettison>1.2</version.jettison>
         <version.jsch>0.1.48</version.jsch>
         <version.jta>1.1</version.jta>
         <version.junit>4.10</version.junit>
         <version.jruby>1.7.2</version.jruby>
         <version.jython>2.5.3</version.jython>
-        <version.kie>6.0.0.CR5</version.kie>
+        <version.kie>6.0.0.Final</version.kie>
         <version.littleproxy>0.5.3</version.littleproxy>
         <version.maven.clean.plugin>2.5</version.maven.clean.plugin>
         <version.maven.plugin.plugin>3.1</version.maven.plugin.plugin>
@@ -2292,61 +2292,6 @@
             <dependency>
                 <groupId>org.kie</groupId>
                 <artifactId>kie-internal</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-commons-cdi</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-commons-data</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-commons-io</artifactId>
-                <version>${version.kie}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>net.sf.josql</groupId>
-                        <artifactId>josql</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>net.sf.josql</groupId>
-                        <artifactId>gentlyweb-utils</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-commons-regex</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-commons-validation</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-nio2-api</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-nio2-fs</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-nio2-jgit</artifactId>
-                <version>${version.kie}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.kie.commons</groupId>
-                <artifactId>kie-nio2-model</artifactId>
                 <version>${version.kie}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
SWITCHYARD-1825: Upgrade KIE/Drools/jBPM from 6.0.0.CR5 to 6.0.0.Final
https://issues.jboss.org/browse/SWITCHYARD-1825
