### PR TITLE
SWITCHYARD-1998 Add support for Camel RSS component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,8 @@
         
         <!-- Versions for dependencies that conflict with the Integration BOM -->
         <version.beanshell>2.0b5</version.beanshell>
+        <version.org.apache.ws.commons.axiom>1.2.14</version.org.apache.ws.commons.axiom>
+        <version.org.apache.abdera>1.1.3</version.org.apache.abdera>
         
         <!-- Require investigation and/or will be removed  -->
         <version.arquillian.container>7.1.3.Final</version.arquillian.container>
@@ -93,7 +95,6 @@
         <version.jbossws.jboss720.server.integration>4.2.0.Final</version.jbossws.jboss720.server.integration>
         <version.redhat.eap6>6.1</version.redhat.eap6>
         <version.redhat.eap6.minor>0.Alpha</version.redhat.eap6.minor>
-        
         
     </properties>
     <scm>
@@ -624,6 +625,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency> 
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-rss</artifactId>
+                <version>${version.org.apache.camel}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-atom</artifactId>
@@ -823,6 +829,25 @@
                     <exclusion>
                         <groupId>org.beanshell</groupId>
                         <artifactId>bsh</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.abdera</groupId>
+                <artifactId>abdera-core</artifactId>
+                <version>${version.org.apache.abdera}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-activation_1.0.2_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1579,6 +1604,11 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard.components</groupId>
+                <artifactId>switchyard-component-camel-rss</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.switchyard.components</groupId>
                 <artifactId>switchyard-component-camel-sql</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1760,6 +1790,11 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard.quickstarts</groupId>
+                <artifactId>switchyard-camel-rss-binding</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.switchyard.quickstarts</groupId>
                 <artifactId>switchyard-camel-sql-binding</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1926,7 +1961,11 @@
                 <artifactId>switchyard-demo-policy-transaction</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+            <dependency>
+                <groupId>rome</groupId>
+                <artifactId>rome</artifactId>
+                <version>${version.rome}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <distributionManagement>


### PR DESCRIPTION
Please note that this request involves bumping versions of abdera and axiom.     I've done some testing on the bpel-console and saw no issues there with the newer versions of those JARs.

We would need to get the integration versions of these jars upgraded.
