### PR TITLE
SWITCHYARD-1998 Add support for Camel RSS component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@
         
         <!-- Versions for dependencies that conflict with the Integration BOM -->
         <version.beanshell>2.0b5</version.beanshell>
+        <version.org.apache.ws.commons.axiom>1.2.14</version.org.apache.ws.commons.axiom>
+        <version.org.apache.abdera>1.1.3</version.org.apache.abdera>
         
         <!-- Require investigation and/or will be removed  -->
         <version.arquillian.container>7.1.3.Final</version.arquillian.container>
@@ -101,8 +103,6 @@
         <version.redhat.eap6>6.1</version.redhat.eap6>
         <version.redhat.eap6.minor>0.Alpha</version.redhat.eap6.minor>
         
-        
-
         <!-- OSGi bundles properties -->
         <switchyard.osgi.import.switchyard.version>version="[$(version;==;${switchyard.osgi.version}),$(version;=+;${switchyard.osgi.version}))"</switchyard.osgi.import.switchyard.version>
         <switchyard.osgi.import.default.version>[$(version;==;$(@)),$(version;+;$(@)))</switchyard.osgi.import.default.version>
@@ -714,6 +714,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency> 
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-rss</artifactId>
+                <version>${version.org.apache.camel}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-atom</artifactId>
@@ -923,7 +928,26 @@
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.bind</groupId>
-                        <artifactId>jaxb-impl</artifactId>
+                        <artifactId>jaxb-impl</artifactId>	
+		    </exclusion>
+		</exclusions>
+            </dependency>
+	    <dependency>
+                <groupId>org.apache.abdera</groupId>
+                <artifactId>abdera-core</artifactId>
+                <version>${version.org.apache.abdera}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-activation_1.0.2_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1705,6 +1729,11 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard.components</groupId>
+                <artifactId>switchyard-component-camel-rss</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.switchyard.components</groupId>
                 <artifactId>switchyard-component-camel-sql</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1901,6 +1930,11 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard.quickstarts</groupId>
+                <artifactId>switchyard-camel-rss-binding</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.switchyard.quickstarts</groupId>
                 <artifactId>switchyard-camel-sql-binding</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -2091,6 +2125,11 @@
                 <groupId>org.apache.karaf</groupId>
                 <artifactId>org.apache.karaf.util</artifactId>
                 <version>${version.karaf}</version>
+	    </dependency>
+            <dependency>
+                <groupId>rome</groupId>
+                <artifactId>rome</artifactId>
+                <version>${version.rome}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Add support for Camel RSS component.    Note that two of the versions added here are in conflict with the integration BOM.    Submitted a pull request to upgrade the integration BOM.    

https://github.com/jboss-integration/jboss-integration-platform-bom/pull/47
