### PR TITLE
SWITCHYARD-2025 Update camel-sap version once Fuse6.1 is released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         
         <!-- Versions for local dependencies not eligible for the Integration BOM -->
         <version.activity.monitor.model>1.2.1.Final</version.activity.monitor.model>
-        <version.camelsap>1.0.0-SNAPSHOT</version.camelsap>
+        <version.camelsap>1.0.0.redhat-379</version.camelsap>
         <version.commons-lang3>3.1</version.commons-lang3>
         <!-- This version is only used as a prefix for a jar included in release modules -->
         <version.deltaspike>0.3-incubating</version.deltaspike>
@@ -178,8 +178,8 @@
             </snapshots>
         </repository>
         <repository>
-            <id>fusesource-public-snapshots-repository-group</id>
-            <url>http://repository.jboss.org/nexus/content/groups/fs-public-snapshots</url>
+            <id>fusesource-public-release-repository-group</id>
+            <url>https://repository.jboss.org/nexus/content/repositories/fs-releases</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>


### PR DESCRIPTION
Updated to the released version of camel-sap bundled with Fuse 6.1 and tested with the camel-sap-binding quickstart again.
