### PR TITLE
SWITCHYARD-2397: Upgrade Drools/jBPM to 6.2.0.BetaX and RuntimeEngine refactoring

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,10 @@
         <version.ip.bom>6.0.0.CR14</version.ip.bom>
         <version.org.jboss.as>7.4.0.Final-redhat-19</version.org.jboss.as>
         <version.redhat.eap6.bom>6.3.0.GA</version.redhat.eap6.bom>
-        <version.org.mvel>2.2.1.Final</version.org.mvel>
+        <!-- KIE/Drools/jBPM: these should all match -->
+        <version.org.kie>6.2.0.Beta3</version.org.kie>
+        <version.org.drools>6.2.0.Beta3</version.org.drools>
+        <version.org.jbpm>6.2.0.Beta3</version.org.jbpm>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -38,6 +41,27 @@
                 <groupId>org.jboss.integration-platform</groupId>
                 <artifactId>jboss-integration-platform-bom</artifactId>
                 <version>${version.ip.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.kie</groupId>
+                <artifactId>kie-bom</artifactId>
+                <version>${version.org.kie}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-bom</artifactId>
+                <version>${version.org.drools}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jbpm</groupId>
+                <artifactId>jbpm-bom</artifactId>
+                <version>${version.org.jbpm}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,10 @@
         <!-- Remove when RiftSaw upgrades to net.sf.saxon:Saxon-HE:9.5.1-2  -->
         <version.net.sourceforge.saxon>9.2.1.5</version.net.sourceforge.saxon>
 
-        <!-- KIE/Drools/jBPM -->
-        <version.kiedroolsjbpm>6.1.0.Final</version.kiedroolsjbpm>
-        <version.org.kie>${version.kiedroolsjbpm}</version.org.kie>
-        <version.org.drools>${version.kiedroolsjbpm}</version.org.drools>
-        <version.org.jbpm>${version.kiedroolsjbpm}</version.org.jbpm>
+        <!-- KIE/Drools/jBPM: these should all match -->
+        <version.org.kie>6.2.0.Beta3</version.org.kie>
+        <version.org.drools>6.2.0.Beta3</version.org.drools>
+        <version.org.jbpm>6.2.0.Beta3</version.org.jbpm>
 
         <!-- Require investigation and/or will be removed  -->
         <version.jbossws.jboss720.server.integration>4.2.0.Final</version.jbossws.jboss720.server.integration>


### PR DESCRIPTION
SWITCHYARD-2397: Upgrade Drools/jBPM to 6.2.0.BetaX and RuntimeEngine refactoring
https://issues.jboss.org/browse/SWITCHYARD-2397
