### PR TITLE
SWITCHYARD-2314 Rename cxf quickstart to match convention used by other quickstarts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1392,7 +1392,7 @@
             </dependency>
             <dependency>
                 <groupId>org.switchyard.quickstarts</groupId>
-                <artifactId>switchyard-camel-cxf</artifactId>
+                <artifactId>switchyard-camel-cxf-binding</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Rename camel-cxf quickstart.
