### PR TITLE
SWITCHYARD-2488: Upgrade KIE/Drools/jBPM from 6.2.0.Beta3 to 6.2.0.CR3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,9 +31,9 @@
         <version.org.jboss.as>7.4.0.Final-redhat-19</version.org.jboss.as>
         <version.redhat.eap6.bom>6.3.0.GA</version.redhat.eap6.bom>
         <!-- KIE/Drools/jBPM: these should all match -->
-        <version.org.kie>6.2.0.Beta3</version.org.kie>
-        <version.org.drools>6.2.0.Beta3</version.org.drools>
-        <version.org.jbpm>6.2.0.Beta3</version.org.jbpm>
+        <version.org.kie>6.2.0.CR3</version.org.kie>
+        <version.org.drools>6.2.0.CR3</version.org.drools>
+        <version.org.jbpm>6.2.0.CR3</version.org.jbpm>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <!-- Remove when RiftSaw upgrades to net.sf.saxon:Saxon-HE:9.5.1-2  -->
         <version.net.sourceforge.saxon>9.2.1.5</version.net.sourceforge.saxon>
         <!-- KIE/Drools/jBPM: these should all match -->
-        <version.org.kie>6.2.0.Beta3</version.org.kie>
-        <version.org.drools>6.2.0.Beta3</version.org.drools>
-        <version.org.jbpm>6.2.0.Beta3</version.org.jbpm>
+        <version.org.kie>6.2.0.CR3</version.org.kie>
+        <version.org.drools>6.2.0.CR3</version.org.drools>
+        <version.org.jbpm>6.2.0.CR3</version.org.jbpm>
         <!-- Require investigation and/or will be removed  -->
         <version.jbossws.jboss720.server.integration>4.2.0.Final</version.jbossws.jboss720.server.integration>
         <!-- Plugin versions -->


### PR DESCRIPTION
SWITCHYARD-2488: Upgrade KIE/Drools/jBPM from 6.2.0.Beta3 to 6.2.0.CR3
https://issues.jboss.org/browse/SWITCHYARD-2488
